### PR TITLE
Enable ZeRO set/get APIs for NVMe offload

### DIFF
--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -55,5 +55,5 @@ jobs:
         run: |
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           cd tests
-          pytest $PYTEST_OPTS --forked -n 8 unit/ --torch_ver="2.6" --cuda_ver="12.4"
+          pytest -x $PYTEST_OPTS --forked -n 8 unit/ --torch_ver="2.6" --cuda_ver="12.4"
           pytest $PYTEST_OPTS --forked -m 'sequential' unit/ --torch_ver="2.6" --cuda_ver="12.4"

--- a/deepspeed/runtime/swap_tensor/__init__.py
+++ b/deepspeed/runtime/swap_tensor/__init__.py
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team
+from .utils import MIN_SWAPPABLE_BYTES

--- a/deepspeed/runtime/swap_tensor/optimizer_utils.py
+++ b/deepspeed/runtime/swap_tensor/optimizer_utils.py
@@ -26,35 +26,53 @@ class FlattenedTensorSwapInfo(object):
         self.length = length
 
 
+class SwapTensorContext(object):
+
+    def __init__(self, tensor, swap_folder):
+        self.compute_tensor = tensor
+        self.swap_tensor = torch.Tensor()
+        self.swap_path = os.path.join(swap_folder, f'{OptimizerSwapper.parameter_id(tensor)}.tensor.swp')
+
+    def release_memory(self):
+        self.compute_tensor.data = torch.Tensor()
+        self.swap_tensor.data = torch.Tensor()
+
+    def set_buffers(self, compute_buffer, swap_buffer):
+        self.compute_tensor.data = compute_buffer.data
+        self.swap_tensor.data = swap_buffer.data
+
+
 class OptimizerStateSwapInfo(object):
 
     def __init__(self, parameter, numel, base_folder):
         self.tensors = []
         self.param_id = OptimizerSwapper.parameter_id(parameter)
         self.swap_folder = base_folder
-        self.swap_paths = []
         self.swapped_gradients = {}
         self.unswapped_gradients = {}
         self.tensor_numel = numel
         self.tensor_dtype = parameter.dtype
         self.tensor_device = parameter.device
         self.has_state_tensors = False
+        self.swap_buffers = []
         self._add_tensors([parameter])
 
     def numel(self):
         return self.tensor_numel
 
     def has_gradients(self):
-        return self.swapped_gradients or self.unswapped_gradients
+        return bool(self.swapped_gradients) or bool(self.unswapped_gradients)
 
     def _add_tensors(self, tensor_list):
         for t in tensor_list:
-            self.tensors.append(t)
-            self.swap_paths.append(os.path.join(self.swap_folder, f'{OptimizerSwapper.parameter_id(t)}.tensor.swp'))
+            self.tensors.append(SwapTensorContext(t, self.swap_folder))
 
     def add_state_tensors(self, tensor_list):
         self.has_state_tensors = True
         self._add_tensors(tensor_list)
+
+    def num_tensors(self):
+        return len(self.tensors)
 
     def device(self):
         return self.tensor_device
@@ -63,8 +81,23 @@ class OptimizerStateSwapInfo(object):
         return self.tensor_dtype
 
     def release_memory(self):
-        for tensor in self.tensors:
-            tensor.data = torch.Tensor()
+        for t in self.tensors:
+            t.release_memory()
+
+    def get_compute_tensors(self):
+        return [t.compute_tensor for t in self.tensors]
+
+    def get_swap_paths(self):
+        return [t.swap_path for t in self.tensors]
+
+    def get_swap_buffers_and_paths(self, pinned):
+        swap_buffers = []
+        swap_paths = []
+        select_tensors = [t for t in self.tensors if get_accelerator().is_pinned(t.compute_tensor) == pinned]
+        for t in select_tensors:
+            swap_buffers.append(t.swap_tensor if pinned else t.compute_tensor)
+            swap_paths.append(t.swap_path)
+        return swap_buffers, swap_paths
 
     def get_or_create_gradient_paths(self, offsets, lengths):
         gradient_paths = []
@@ -77,11 +110,15 @@ class OptimizerStateSwapInfo(object):
 
         return gradient_paths
 
-    def set_swap_buffers(self, buffers):
-        compute_lengths = [self.numel()] * len(self.tensors)
+    def set_swap_buffers(self, buffers, aligned_numel):
+        num_tensors = len(self.tensors)
+        compute_lengths = [self.numel()] * num_tensors
         compute_buffers = get_sized_buffers(buffers, compute_lengths)
-        for t, buffer in zip(self.tensors, compute_buffers):
-            t.data = buffer.data
+        swap_lengths = [aligned_numel] * num_tensors
+        swap_buffers = get_sized_buffers(buffers, swap_lengths)
+
+        for i, t in enumerate(self.tensors):
+            t.set_buffers(compute_buffer=compute_buffers[i], swap_buffer=swap_buffers[i])
 
     def get_swap_gradient_buffers(self, swap_buffer):
         assert self.numel() <= swap_buffer.numel()
@@ -91,13 +128,22 @@ class OptimizerStateSwapInfo(object):
         return [grad.path for grad in self.swapped_gradients.values()]
 
     def get_unpinned_state_tensors(self):
-        return [t for t in self.tensors if not get_accelerator().is_pinned(t)]
+        return [t.compute_tensor for t in self.tensors if not get_accelerator().is_pinned(t.compute_tensor)]
 
     def read_unswapped_gradients(self, dest_buffer):
         num_elem_count = 0
         for offset, grad_partition in self.unswapped_gradients.items():
             dst_tensor = dest_buffer.narrow(0, offset, grad_partition.numel())
             dst_tensor.data.copy_(grad_partition.data)
+            num_elem_count += grad_partition.numel()
+
+        return num_elem_count
+
+    def write_unswapped_gradients(self, src_buffer):
+        num_elem_count = 0
+        for offset, grad_partition in self.unswapped_gradients.items():
+            src_tensor = src_buffer.narrow(0, offset, grad_partition.numel())
+            grad_partition.data.copy_(src_tensor.data)
             num_elem_count += grad_partition.numel()
 
         return num_elem_count
@@ -158,10 +204,10 @@ class OptimizerSwapper(object):
             swap_info.tensors = [swap_info.tensors[0]]
             swap_info.has_state_tensors = False
 
-    def swappable_tensor(self, param=None, numel=None):
-        assert param is not None or numel is not None, "Either param or numel must be provided"
-        if param is not None:
-            return self.min_aio_bytes <= (param.numel() * self.swap_element_size)
+    def is_swappable_tensor(self, tensor=None, numel=None):
+        assert tensor is not None or numel is not None, "Either tensor or numel must be provided"
+        if tensor is not None:
+            return self.min_aio_bytes <= (tensor.numel() * self.swap_element_size)
         return self.min_aio_bytes <= (numel * self.swap_element_size)
 
     def init_timers(self):
@@ -201,7 +247,7 @@ class OptimizerSwapper(object):
 
         self._start_timer(SWAP_OUT_GRADIENT_TIMER)
         for tensor, offset in zip(aligned_gradients, aligned_offsets):
-            if not self.swappable_tensor(param=tensor):
+            if not self.is_swappable_tensor(tensor=tensor):
                 swap_info.unswapped_gradients[offset] = tensor
                 continue
 
@@ -355,7 +401,7 @@ class OptimizerSwapper(object):
         ]
         assert len(swap_info_list) == len(num_elems)
 
-        swap_paths = [info.swap_paths[0] for info in swap_info_list]
+        swap_paths = [info.tensors[0].swap_path for info in swap_info_list]
         return swap_paths
 
     def _swap_out_unpinned_tensors(self, aio_handle, unpinned_tensors, dest_paths, pinned_buffers):
@@ -386,7 +432,7 @@ class OptimizerSwapper(object):
         new_offsets = []
 
         for orig_tensor, orig_offset in zip(tensors, offsets):
-            if not self.swappable_tensor(param=orig_tensor):
+            if not self.is_swappable_tensor(tensor=orig_tensor):
                 new_tensors.append(orig_tensor)
                 new_offsets.append(orig_offset)
                 continue
@@ -430,7 +476,7 @@ class OptimizerSwapper(object):
 
         tensor_list = []
         for state_name, value in self.optimizer.state[parameter].items():
-            if torch.is_tensor(value):
+            if torch.is_tensor(value) and self.is_swappable_tensor(tensor=value):
                 value.ds_id = state_name + '-' + parameter.ds_id
                 tensor_list.append(value)
 

--- a/deepspeed/runtime/swap_tensor/partitioned_optimizer_swapper.py
+++ b/deepspeed/runtime/swap_tensor/partitioned_optimizer_swapper.py
@@ -6,8 +6,6 @@
 Functionality of swapping optimizer tensors to/from (NVMe) storage devices.
 """
 
-import torch
-
 from deepspeed.utils.logging import logger
 from deepspeed.ops.op_builder import AsyncIOBuilder
 from deepspeed import comm as dist
@@ -63,6 +61,15 @@ class PartitionedOptimizerSwapper(OptimizerSwapper):
     def flush_gradients(self):
         self._flush_gradient_swapper(self.gradient_swapper)
 
+    def release_swap_buffers(self, parameter):
+        swap_info = self._get_param_swap_info(parameter)
+        if swap_info is None:
+            return
+        swap_info.release_memory()
+
+        self.swap_buffer_manager.free(swap_info.swap_buffers)
+        swap_info.swap_buffers = []
+
     def swap_in_optimizer_state(self, parameter, async_parameter=None):
         swap_info = self._get_param_swap_info(parameter)
         if swap_info is None:
@@ -70,25 +77,66 @@ class PartitionedOptimizerSwapper(OptimizerSwapper):
 
         self._flush_gradient_swapper(self.gradient_swapper)
 
-        required_buffer_count = len(swap_info.tensors) + (1 if swap_info.has_gradients() else 0)
+        required_buffer_count = swap_info.num_tensors() + (1 if swap_info.has_gradients() else 0)
         aligned_numel = self._io_aligned_numel(swap_info.numel())
         pinned_buffers = self.swap_buffer_manager.allocate(num_elems=aligned_numel,
                                                            count=required_buffer_count,
                                                            dtype=parameter.dtype)
         assert pinned_buffers is not None
-        self.allocated_swap_buffers = pinned_buffers.copy()
+        swap_info.swap_buffers = pinned_buffers.copy()
 
         self._start_timer(SWAP_IN_PARAM_TIMER)
         self._swap_in_parameter(aio_handle=self.aio_handle,
                                 parameter=parameter,
-                                dest_buffers=pinned_buffers[:required_buffer_count])
+                                dest_buffers=pinned_buffers[:swap_info.num_tensors()])
         self._stop_timer(SWAP_IN_PARAM_TIMER)
         self.timer_names.add(SWAP_IN_PARAM_TIMER)
 
-        self._start_timer(SWAP_IN_GRADIENT_TIMER)
-        self._swap_in_gradients(aio_handle=self.aio_handle, parameter=parameter, dest_buffer=pinned_buffers[-1])
-        self._stop_timer(SWAP_IN_GRADIENT_TIMER)
-        self.timer_names.add(SWAP_IN_GRADIENT_TIMER)
+        if swap_info.has_gradients():
+            self._start_timer(SWAP_IN_GRADIENT_TIMER)
+            self._swap_in_gradients(aio_handle=self.aio_handle, parameter=parameter, dest_buffer=pinned_buffers[-1])
+            self._stop_timer(SWAP_IN_GRADIENT_TIMER)
+            self.timer_names.add(SWAP_IN_GRADIENT_TIMER)
+
+    def _swap_out_optimizer_state(self, swap_info):
+        pinned_tensors, pinned_paths = swap_info.get_swap_buffers_and_paths(True)
+        WRITE_TIMER = 'swap_submit_write'
+        self._start_timer(WRITE_TIMER)
+
+        swap_out_tensors(self.aio_handle, pinned_tensors, pinned_paths)
+        assert self.aio_handle.wait() == len(pinned_tensors)
+
+        unpinned_tensors, unpinned_paths = swap_info.get_swap_buffers_and_paths(False)
+        if len(unpinned_tensors) > 0:
+            pinned_buffers = self.swap_buffer_manager.allocate_all(num_elems=self.largest_numel, dtype=self.dtype)
+            self._swap_out_unpinned_tensors(aio_handle=self.aio_handle,
+                                            unpinned_tensors=unpinned_tensors,
+                                            dest_paths=unpinned_paths,
+                                            pinned_buffers=pinned_buffers)
+            swap_info.swap_buffers += pinned_buffers.copy()
+
+        self._stop_timer(WRITE_TIMER)
+        self._log_timers([WRITE_TIMER])
+
+    def writeback_optimizer_state_and_gradients(self, parameter, write_opt_state, write_gradients):
+        swap_info = self._get_param_swap_info(parameter=parameter)
+
+        if swap_info is None:
+            return
+
+        if write_opt_state:
+            self._swap_out_optimizer_state(swap_info)
+
+        if write_gradients and swap_info.has_gradients():
+            param_gradients = swap_info.swapped_gradients.values()
+            swap_buffers = [parameter.grad.narrow(0, grad.offset, grad.length) for grad in param_gradients]
+            swap_paths = [grad.path for grad in param_gradients]
+            swap_out_tensors(self.aio_handle, swap_buffers, swap_paths)
+            assert len(swap_buffers) == self.aio_handle.wait()
+            if swap_info.unswapped_gradients:
+                swap_info.write_unswapped_gradients(src_buffer=parameter.grad)
+
+        self.release_swap_buffers(parameter)
 
     def swap_out_optimizer_state(self, parameter, async_swap=False):
         swap_info = self._get_param_swap_info(parameter=parameter)
@@ -96,37 +144,14 @@ class PartitionedOptimizerSwapper(OptimizerSwapper):
         if swap_info is None:
             return
 
+        swap_bytes = sum(
+            [self._io_aligned_numel(t.numel()) * t.element_size() for t in swap_info.get_compute_tensors()])
+
         self._start_timer(SWAP_OUT_PARAM_TIMER)
-        pinned_tensors, pinned_paths, unpinned_tensors, unpinned_paths = self._separate_pinned_tensors(swap_info)
-        swap_bytes = sum([self._io_aligned_numel(t.numel()) * t.element_size() for t in swap_info.tensors])
-
-        WRITE_TIMER = 'swap_submit_write'
-        self._start_timer(WRITE_TIMER)
-
-        swap_out_tensors(self.aio_handle, pinned_tensors, pinned_paths)
-        assert self.aio_handle.wait() == len(pinned_tensors)
-        for t in pinned_tensors:
-            t.data = torch.Tensor()
-
-        if len(unpinned_tensors) > 0:
-            pinned_buffers = self.swap_buffer_manager.allocate_all(num_elems=self.largest_numel, dtype=self.dtype)
-            self._swap_out_unpinned_tensors(aio_handle=self.aio_handle,
-                                            unpinned_tensors=unpinned_tensors,
-                                            dest_paths=unpinned_paths,
-                                            pinned_buffers=pinned_buffers)
-            self.allocated_swap_buffers += pinned_buffers
-
-            for t in unpinned_tensors:
-                t.data = torch.Tensor()
-        self._stop_timer(WRITE_TIMER)
-
-        self.swap_buffer_manager.free(self.allocated_swap_buffers)
-        self.allocated_swap_buffers = []
-
+        self._swap_out_optimizer_state(swap_info)
+        self.release_swap_buffers(parameter)
         self._stop_timer(SWAP_OUT_PARAM_TIMER)
         self.timer_names.add(SWAP_OUT_PARAM_TIMER)
-
-        self._log_timers([WRITE_TIMER])
 
         if DEBUG_MODE and dist.get_rank() == 0:
             logger.info(f'optimizer_param_swap_out: {(swap_bytes/(1024**3)):5.2f} GB')
@@ -142,16 +167,20 @@ class PartitionedOptimizerSwapper(OptimizerSwapper):
         if swap_info is None:
             return
 
-        assert len(swap_info.tensors) <= len(dest_buffers)
+        num_swap_tensors = swap_info.num_tensors()
+        assert num_swap_tensors <= len(dest_buffers)
 
-        swap_lengths = [self._io_aligned_numel(swap_info.numel())] * len(swap_info.tensors)
+        swap_lengths = [self._io_aligned_numel(swap_info.numel())] * num_swap_tensors
         swap_buffers = get_sized_buffers(dest_buffers, swap_lengths)
+
+        compute_lengths = [swap_info.numel()] * num_swap_tensors
+        compute_buffers = get_sized_buffers(dest_buffers, compute_lengths)
 
         READ_TIMER = 'swap_submit_read_param'
         WAIT_TIMER = 'swap_wait_read_param'
 
         self._start_timer(READ_TIMER)
-        swap_in_tensors(aio_handle, swap_buffers, swap_info.swap_paths)
+        swap_in_tensors(aio_handle, swap_buffers, swap_info.get_swap_paths())
         self._stop_timer(READ_TIMER)
 
         swap_bytes = sum([buffer.numel() * buffer.element_size() for buffer in swap_buffers])
@@ -160,31 +189,11 @@ class PartitionedOptimizerSwapper(OptimizerSwapper):
         aio_handle.wait()
         self._stop_timer(WAIT_TIMER)
 
-        compute_lengths = [swap_info.numel()] * len(swap_info.tensors)
-        compute_buffers = get_sized_buffers(dest_buffers, compute_lengths)
-        for t, buffer in zip(swap_info.tensors, compute_buffers):
-            t.data = buffer.data
+        swap_info.set_swap_buffers(dest_buffers, self._io_aligned_numel(swap_info.numel()))
 
         self._log_timers([READ_TIMER, WAIT_TIMER])
         if DEBUG_MODE and dist.get_rank() == 0:
             logger.info(f'optimizer_param_swap_in: {(swap_bytes/(1024**3)):5.2f} GB')
-
-    def _separate_pinned_tensors(self, swap_info):
-        pinned_tensors = []
-        pinned_paths = []
-
-        unpinned_tensors = []
-        unpinned_paths = []
-
-        for tensor, path in zip(swap_info.tensors, swap_info.swap_paths):
-            if get_accelerator().is_pinned(tensor):
-                pinned_tensors.append(tensor)
-                pinned_paths.append(path)
-            else:
-                unpinned_tensors.append(tensor)
-                unpinned_paths.append(path)
-
-        return pinned_tensors, pinned_paths, unpinned_tensors, unpinned_paths
 
     def _swap_in_pinned_gradients(self, aio_handle, parameter, gradient_tensor):
         swap_info = self.swap_params_info[OptimizerSwapper.parameter_id(parameter)]
@@ -193,7 +202,6 @@ class PartitionedOptimizerSwapper(OptimizerSwapper):
         swap_paths = [grad.path for grad in param_gradients]
         SWAP_READ_GRADIENTS = 'swap_submit_read_gradient'
         SWAP_WAIT_GRADIENTS = 'swap_submit_wait_gradient'
-
         self._start_timer(SWAP_READ_GRADIENTS)
         swap_in_tensors(aio_handle, swap_buffers, swap_paths)
         self._stop_timer(SWAP_READ_GRADIENTS)

--- a/deepspeed/runtime/swap_tensor/pipelined_optimizer_swapper.py
+++ b/deepspeed/runtime/swap_tensor/pipelined_optimizer_swapper.py
@@ -187,7 +187,7 @@ class PipelinedOptimizerSwapper(OptimizerSwapper):
                 dst = get_sized_buffer(pinned_dst, unpinned_src.numel())
                 dst.data.copy_(unpinned_src.data)
 
-        swap_paths = param_info.swap_paths.copy()
+        swap_paths = param_info.get_swap_paths()
         assert len(swap_paths) == len(swap_buffers)
 
         swap_out_tensors(aio_handle, swap_buffers, swap_paths)
@@ -206,7 +206,8 @@ class PipelinedOptimizerSwapper(OptimizerSwapper):
         if param_info is None:
             return None
 
-        required_buffer_count = len(param_info.tensors) + (1 if param_info.has_gradients() else 0)
+        num_swap_tensors = param_info.num_tensors()
+        required_buffer_count = num_swap_tensors + (1 if param_info.has_gradients() else 0)
         aligned_numel = self._io_aligned_numel(param_info.numel())
         allocated_buffers = self.swap_buffer_manager.allocate(num_elems=aligned_numel,
                                                               count=required_buffer_count,
@@ -214,11 +215,11 @@ class PipelinedOptimizerSwapper(OptimizerSwapper):
         assert allocated_buffers is not None, \
         f"PipelinedOptimizerSwapper ran out of swap buffers, try increasing 'buffer_count'"
 
-        state_buffers = allocated_buffers[:len(param_info.tensors)]
-        param_info.set_swap_buffers(state_buffers)
+        state_buffers = allocated_buffers[:num_swap_tensors]
+        param_info.set_swap_buffers(state_buffers, aligned_numel)
 
         swap_buffers = state_buffers.copy()
-        swap_paths = param_info.swap_paths.copy()
+        swap_paths = param_info.get_swap_paths()
 
         if param_info.has_gradients():
             parameter.grad = allocated_buffers[-1].narrow(0, 0, param_info.numel())

--- a/deepspeed/runtime/swap_tensor/utils.py
+++ b/deepspeed/runtime/swap_tensor/utils.py
@@ -14,6 +14,7 @@ from deepspeed import comm as dist
 
 MIN_AIO_BYTES = 1024**2
 AIO_ALIGNED_BYTES = 1024
+MIN_SWAPPABLE_BYTES = MIN_AIO_BYTES
 
 
 def swap_in_tensors(swap_handle, tensor_buffers, swap_paths):

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -991,8 +991,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         if not self.swap_optimizer:
             return False
 
-        return self.optimizer_swapper.swappable_tensor(None,
-                                                       numel=self.fp16_partitioned_groups_flat_numel[sub_group_id])
+        return self.optimizer_swapper.is_swappable_tensor(None,
+                                                          numel=self.fp16_partitioned_groups_flat_numel[sub_group_id])
 
     def _partitioned_params_swap_out(self, i):
         offset = 0
@@ -1918,21 +1918,23 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             self._prepare_fp32_grad_for_sub_group(sub_group_id)
         see_memory_usage(f'After prepare optimizer sub group {sub_group_id}', force=False)
 
-    def _optimizer_states_and_gradient_swap_in(self, sub_group_id, timer_names):
+    def _optimizer_states_and_gradient_swap_in(self, sub_group_id, timer_names=None):
         param_length = self.fp16_partitioned_groups_flat_numel[sub_group_id]
         fp32_param_id = self.get_param_id(self.fp32_partitioned_groups_flat[sub_group_id])
         assert self._swappable_optimizer_subgroup(sub_group_id), \
             f'Parameter {fp32_param_id} of numel={param_length} is not swappable'
 
         see_memory_usage(f'pre-step Before swapping in optimizer tensors {sub_group_id}', force=False)
-        timer_names.add(OPTIMIZER_SWAP_IN_STATE_TIMER)
-        self.timers(OPTIMIZER_SWAP_IN_STATE_TIMER).start()
+        if timer_names is not None:
+            timer_names.add(OPTIMIZER_SWAP_IN_STATE_TIMER)
+            self.timers(OPTIMIZER_SWAP_IN_STATE_TIMER).start()
 
         self.optimizer_swapper.swap_in_optimizer_state(
             parameter=self.fp32_partitioned_groups_flat[sub_group_id],
             async_parameter=self.next_swappable_fp32_partitioned_groups[sub_group_id])
 
-        self.timers(OPTIMIZER_SWAP_IN_STATE_TIMER).stop()
+        if timer_names is not None:
+            self.timers(OPTIMIZER_SWAP_IN_STATE_TIMER).stop()
         see_memory_usage(f'pre-step After swapping in optimizer tensors {sub_group_id}', force=False)
 
     @instrument_w_nvtx
@@ -1966,24 +1968,35 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
 
         return self.flatten(padded_tensor_list)
 
-    def _optimizer_states_and_gradient_swap_out(self, sub_group_id, timer_names):
+    def _optimizer_states_and_gradient_swap_out(self, sub_group_id, timer_names=None):
         param_length = self.fp16_partitioned_groups_flat_numel[sub_group_id]
         fp32_param_id = self.get_param_id(self.fp32_partitioned_groups_flat[sub_group_id])
         assert self._swappable_optimizer_subgroup(sub_group_id), \
             f'Parameter {fp32_param_id} of numel={param_length} is not swappable'
 
         see_memory_usage(f'post-step Before swapping out optimizer tensors {sub_group_id}', force=False)
-        timer_names.add(OPTIMIZER_SWAP_OUT_STATE_TIMER)
-        self.timers(OPTIMIZER_SWAP_OUT_STATE_TIMER).start()
+        if timer_names is not None:
+            timer_names.add(OPTIMIZER_SWAP_OUT_STATE_TIMER)
+            self.timers(OPTIMIZER_SWAP_OUT_STATE_TIMER).start()
 
         self.optimizer_swapper.swap_out_optimizer_state(
             parameter=self.fp32_partitioned_groups_flat[sub_group_id],
             async_swap=self.next_swappable_fp32_partitioned_groups[sub_group_id] is not None)
 
-        self.timers(OPTIMIZER_SWAP_OUT_STATE_TIMER).stop()
+        if timer_names is not None:
+            self.timers(OPTIMIZER_SWAP_OUT_STATE_TIMER).stop()
         see_memory_usage(f'post-step After swapping out optimizer tensors {sub_group_id}', force=False)
 
         # get rid of the fp32 gradients. Not needed anymore
+        self.fp32_partitioned_groups_flat[sub_group_id].grad = None
+
+    def _release_swap_buffers(self, sub_group_id):
+        self.optimizer_swapper.release_swap_buffers(parameter=self.fp32_partitioned_groups_flat[sub_group_id])
+        self.fp32_partitioned_groups_flat[sub_group_id].grad = None
+
+    def _writeback_swap_state(self, sub_group_id, write_opt_state, write_gradients):
+        self.optimizer_swapper.writeback_optimizer_state_and_gradients(self.fp32_partitioned_groups_flat[sub_group_id],
+                                                                       write_opt_state, write_gradients)
         self.fp32_partitioned_groups_flat[sub_group_id].grad = None
 
     def _unflatten_partitioned_parameters(self, sub_group_id):
@@ -2312,40 +2325,55 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         dist.all_gather_into_tensor(reduce_buffer, partition, group=self.dp_process_group)
         return reduce_buffer.narrow(0, 0, param.ds_numel).view(param.ds_shape)
 
+    def _get_fp32_grad_state_partition(self, param, release_swap_buffers):
+        if not get_accelerator().resolves_data_dependency():
+            self.reduce_and_partition_stream.synchronize()
+
+        group_idx, dest_offset, num_elements = self.grad_position[self.get_param_id(param)]
+        if self.offload_optimizer:
+            if self._swappable_optimizer_subgroup(group_idx):
+                self._optimizer_states_and_gradient_swap_in(group_idx)
+
+            fp32_grad = self.fp32_partitioned_groups_flat[group_idx].grad.narrow(0, dest_offset, num_elements)
+
+            if self._swappable_optimizer_subgroup(group_idx) and release_swap_buffers:
+                self._release_swap_buffers(group_idx)
+        else:
+            fp32_grad = self.__param_id_to_grad_partition[param.ds_id]
+
+        return fp32_grad, group_idx
+
     def get_fp32_grad_for_param(self, param) -> Tensor:
         if not param.requires_grad:
             return None
 
-        if not get_accelerator().resolves_data_dependency():
-            self.reduce_and_partition_stream.synchronize()
-
-        if self.offload_optimizer:
-            group_idx, dest_offset, num_elements = self.grad_position[self.get_param_id(param)]
-            fp32_grad = self.fp32_partitioned_groups_flat[group_idx].grad.narrow(0, dest_offset, num_elements)
-        else:
-            fp32_grad = self.__param_id_to_grad_partition[param.ds_id].float()
-
+        fp32_grad, _ = self._get_fp32_grad_state_partition(param=param, release_swap_buffers=True)
+        fp32_grad = fp32_grad.to(get_accelerator().current_device_name()).float()
         return self._fp32_state_allgather(param, fp32_grad)
 
     def set_fp32_grad_for_param(self, value, param):
         if not param.requires_grad:
             return
 
-        if not get_accelerator().resolves_data_dependency():
-            self.reduce_and_partition_stream.synchronize()
+        # if not get_accelerator().resolves_data_dependency():
+        #     self.reduce_and_partition_stream.synchronize()
 
-        if self.offload_optimizer:
-            group_idx, dest_offset, num_elements = self.grad_position[self.get_param_id(param)]
-            fp32_grad = self.fp32_partitioned_groups_flat[group_idx].grad.narrow(0, dest_offset, num_elements)
-        else:
-            fp32_grad = self.__param_id_to_grad_partition[param.ds_id]
+        # if self.offload_optimizer:
+        #     group_idx, dest_offset, num_elements = self.grad_position[self.get_param_id(param)]
+        #     fp32_grad = self.fp32_partitioned_groups_flat[group_idx].grad.narrow(0, dest_offset, num_elements)
+        # else:
+        #     fp32_grad = self.__param_id_to_grad_partition[param.ds_id]
 
+        fp32_grad, group_idx = self._get_fp32_grad_state_partition(param=param, release_swap_buffers=False)
+        # import pdb; pdb.set_trace()
         my_rank = dist.get_rank(group=self.dp_process_group)
         value_partition = value.flatten().narrow(0, fp32_grad.numel() * my_rank, fp32_grad.numel())
-
         fp32_grad.data.copy_(value_partition.data)
 
-    def _get_fp32_opt_state_partition(self, param, optim_state_key=None):
+        if self._swappable_optimizer_subgroup(group_idx):
+            self._writeback_swap_state(group_idx, write_opt_state=False, write_gradients=True)
+
+    def _get_fp32_opt_state_partition(self, param, release_swap_buffers, optim_state_key=None):
         if not get_accelerator().resolves_data_dependency():
             self.reduce_and_partition_stream.synchronize()
 
@@ -2360,17 +2388,21 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         else:
             fp32_opt_state = self.optimizer.state[fp32_param][optim_state_key].narrow(0, dest_offset, num_elements)
 
+        if self._swappable_optimizer_subgroup(group_idx) and release_swap_buffers:
+            self._release_swap_buffers(group_idx)
+
         return fp32_opt_state, group_idx
 
     def get_full_hp_param(self, param, optim_state_key=None) -> Tensor:
         if not param.requires_grad:
             return None
 
-        fp32_opt_state, group_idx = self._get_fp32_opt_state_partition(param, optim_state_key)
+        # import pdb; pdb.set_trace()
+        fp32_opt_state, group_idx = self._get_fp32_opt_state_partition(param,
+                                                                       release_swap_buffers=True,
+                                                                       optim_state_key=optim_state_key)
+        fp32_opt_state = fp32_opt_state.to(get_accelerator().current_device_name())
         hp_param = self._fp32_state_allgather(param, fp32_opt_state)
-
-        if self._swappable_optimizer_subgroup(group_idx):
-            self._optimizer_states_and_gradient_swap_out(group_idx)
 
         return hp_param
 
@@ -2381,7 +2413,11 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         assert value.numel(
         ) == param.ds_numel, f" Number of elements do not match: {value.numel()} != {param.ds_numel}"
 
-        fp32_opt_state_partition, group_idx = self._get_fp32_opt_state_partition(param, optim_state_key)
+        fp32_opt_state_partition, group_idx = self._get_fp32_opt_state_partition(param,
+                                                                                 release_swap_buffers=False,
+                                                                                 optim_state_key=optim_state_key)
+        # print(f'{dist.get_rank()=}  {fp32_opt_state_partition.shape=} -------- {value.shape=}')
+        # import pdb; pdb.set_trace()
         my_rank = dist.get_rank(group=self.dp_process_group)
         value_partition = value.flatten().narrow(0,
                                                  fp32_opt_state_partition.numel() * my_rank,
@@ -2392,19 +2428,12 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             self._optimizer_states_and_gradient_swap_out(group_idx)
 
     ### Local API START ###
-
     def get_local_fp32_grad_for_param(self, param) -> Tensor:
         if not param.requires_grad:
             return None
 
-        if not get_accelerator().resolves_data_dependency():
-            self.reduce_and_partition_stream.synchronize()
-
-        if self.offload_optimizer:
-            group_idx, dest_offset, num_elements = self.grad_position[self.get_param_id(param)]
-            fp32_grad = self.fp32_partitioned_groups_flat[group_idx].grad.narrow(0, dest_offset, num_elements)
-        else:
-            fp32_grad = self.__param_id_to_grad_partition[param.ds_id].float()
+        fp32_grad, _ = self._get_fp32_grad_state_partition(param=param, release_swap_buffers=True)
+        fp32_grad = fp32_grad.to(get_accelerator().current_device_name()).float()
         return fp32_grad
 
     def set_local_grad_for_param(self, value, param):
@@ -2414,21 +2443,27 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         assert value.numel() == param.ds_tensor.numel(
         ), f" Number of elements do not match: {value.numel()} != {param.ds_tensor.ds_numel}"
 
-        if not get_accelerator().resolves_data_dependency():
-            self.reduce_and_partition_stream.synchronize()
+        # if not get_accelerator().resolves_data_dependency():
+        #     self.reduce_and_partition_stream.synchronize()
 
-        if self.offload_optimizer:
-            group_idx, dest_offset, num_elements = self.grad_position[self.get_param_id(param)]
-            fp32_grad = self.fp32_partitioned_groups_flat[group_idx].grad.narrow(0, dest_offset, num_elements)
-        else:
-            fp32_grad = self.__param_id_to_grad_partition[param.ds_id]
-
+        # if self.offload_optimizer:
+        #     group_idx, dest_offset, num_elements = self.grad_position[self.get_param_id(param)]
+        #     fp32_grad = self.fp32_partitioned_groups_flat[group_idx].grad.narrow(0, dest_offset, num_elements)
+        # else:
+        #     fp32_grad = self.__param_id_to_grad_partition[param.ds_id]
+        fp32_grad, group_idx = self._get_fp32_grad_state_partition(param=param, release_swap_buffers=False)
         fp32_grad.data.copy_(value.flatten().data)
+
+        if self._swappable_optimizer_subgroup(group_idx):
+            self._writeback_swap_state(group_idx, write_opt_state=False, write_gradients=True)
 
     def get_local_fp32_param(self, param, optim_state_key=None) -> Tensor:
         if not param.requires_grad:
             return None
-        fp32_opt_state, group_idx = self._get_fp32_opt_state_partition(param, optim_state_key)
+        fp32_opt_state, group_idx = self._get_fp32_opt_state_partition(param,
+                                                                       release_swap_buffers=True,
+                                                                       optim_state_key=optim_state_key)
+        fp32_opt_state = fp32_opt_state.to(get_accelerator().current_device_name())
         return fp32_opt_state
 
     def set_local_hp_param(self, value, param, optim_state_key=None):
@@ -2439,7 +2474,9 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         assert value.numel() == param.ds_tensor.numel(
         ), f" Number of elements do not match: {value.numel()} != {param.ds_tensor.ds_numel}"
 
-        fp32_opt_state_partition, group_idx = self._get_fp32_opt_state_partition(param, optim_state_key)
+        fp32_opt_state_partition, group_idx = self._get_fp32_opt_state_partition(param,
+                                                                                 release_swap_buffers=False,
+                                                                                 optim_state_key=optim_state_key)
         value_partition = value.flatten()
         fp32_opt_state_partition.data.copy_(value_partition.data)
 
@@ -2448,6 +2485,60 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         # logger.info(f"[set_local_hp_param][update the params' value successfully]")
 
     ### Local API END ###
+
+    ### Vectorized API BEGIN ###
+    def update_fp32_grad_for_param_vectorized(self, update_func, param_list):
+        params_with_grad = [p for p in param_list if p.requires_grad]
+        if not params_with_grad:
+            return
+
+        if not get_accelerator().resolves_data_dependency():
+            self.reduce_and_partition_stream.synchronize()
+
+        subgroups = {}
+        for p in params_with_grad:
+            group_idx, dest_offset, num_elements = self.grad_position[self.get_param_id(p)]
+            param_entry = (p, dest_offset, num_elements)
+            if group_idx in subgroups.keys():
+                subgroups[group_idx].append(param_entry)
+            else:
+                subgroups[group_idx] = [param_entry]
+
+        for group_idx, group_params in subgroups.items():
+            if self._swappable_optimizer_subgroup(group_idx):
+                self._optimizer_states_and_gradient_swap_in(group_idx)
+
+            for param, dest_offset, num_elements in group_params:
+                if self.offload_optimizer:
+                    fp32_grad_part = self.fp32_partitioned_groups_flat[group_idx].grad.narrow(
+                        0, dest_offset, num_elements)
+                else:
+                    fp32_grad_part = self.__param_id_to_grad_partition[param.ds_id]
+
+                fp32_grad_full = self._fp32_state_allgather(param, fp32_grad_part)
+                new_fp32_grad_full = update_func(fp32_grad_full, param)
+                my_rank = dist.get_rank(group=self.dp_process_group)
+                value_partition = new_fp32_grad_full.flatten().narrow(0,
+                                                                      fp32_grad_part.numel() * my_rank,
+                                                                      fp32_grad_part.numel())
+                fp32_grad_part.data.copy_(value_partition.data)
+
+            if self._swappable_optimizer_subgroup(group_idx):
+                self._writeback_swap_state(sub_group_id=group_idx, write_opt_state=False, write_gradients=True)
+
+    ### Vectorized API END ###
+
+    ### Device API BEGIN ###
+    def get_hp_param_device(self, param, optim_state_key=None) -> torch.device:
+        if not param.requires_grad:
+            return None
+
+        fp32_opt_state, _ = self._get_fp32_opt_state_partition(param,
+                                                               release_swap_buffers=True,
+                                                               optim_state_key=optim_state_key)
+        return fp32_opt_state.device
+
+    ### Device API END ###
 
     @instrument_w_nvtx
     def _partition_all_parameters(self):

--- a/deepspeed/utils/__init__.py
+++ b/deepspeed/utils/__init__.py
@@ -16,6 +16,7 @@ from .tensor_fragment import set_full_hp_param, set_full_hp_grad
 from .tensor_fragment import safe_set_full_fp32_param, safe_set_full_optimizer_state, safe_set_full_grad
 from .tensor_fragment import safe_get_local_fp32_param, safe_get_local_grad, safe_get_local_optimizer_state
 from .tensor_fragment import safe_set_local_fp32_param, safe_set_local_grad, safe_set_local_optimizer_state
+from .tensor_fragment import safe_update_full_grad_vectorized
 from .z3_leaf_module import set_z3_leaf_modules, unset_z3_leaf_modules, get_z3_leaf_modules, z3_leaf_module, z3_leaf_parameter, set_z3_leaf_module
 from .mixed_precision_linkage import link_hp_params, lazy_init_hp_params_optimizer_state
 from deepspeed.runtime.dataloader import RepeatingLoader

--- a/tests/unit/runtime/zero/test_offload_states.py
+++ b/tests/unit/runtime/zero/test_offload_states.py
@@ -18,14 +18,14 @@ from deepspeed.utils import safe_get_local_fp32_param, safe_get_local_optimizer_
 from deepspeed.runtime.zero.offload_states import get_state_devices
 
 
-def validate_device(model, device: torch.device, include) -> None:
+def validate_device(model, device: torch.device, offloaded_states) -> None:
 
     def compare_device(state) -> bool:
         devices = get_state_devices(model, state)
         return len(devices) == 1 and device in devices
 
     for state in OffloadStateTypeEnum:
-        if include is None or state in include:
+        if offloaded_states is None or state in offloaded_states:
             if state == OffloadStateTypeEnum.contiguous_grad_buffer and device == torch.device("cpu"):
                 assert len(get_state_devices(model,
                                              state)) == 0, f"State {state} must be removed after offload_states()"
@@ -33,7 +33,7 @@ def validate_device(model, device: torch.device, include) -> None:
                 assert compare_device(state), f"State {state} is not on device {device}"
 
 
-def run_model(model, param_groups, config_dict, hidden_dim, dtype, include, pin_memory, non_blocking):
+def run_model(model, param_groups, config_dict, hidden_dim, dtype, offloaded_states, pin_memory, non_blocking):
     # Currently we only support OffloadDeviceEnum.cpu
     offload_device = OffloadDeviceEnum.cpu
 
@@ -57,11 +57,14 @@ def run_model(model, param_groups, config_dict, hidden_dim, dtype, include, pin_
 
         # Start offloading
         alloc_before_offload = get_accelerator().memory_allocated()
-        model.offload_states(include=include, device=offload_device, pin_memory=pin_memory, non_blocking=non_blocking)
+        model.offload_states(include=offloaded_states,
+                             device=offload_device,
+                             pin_memory=pin_memory,
+                             non_blocking=non_blocking)
         alloc_after_offload = get_accelerator().memory_allocated()
         assert alloc_after_offload < alloc_before_offload, f"Allocated memory should decrease after offload"
 
-        validate_device(model, torch.device(offload_device.value), include)
+        validate_device(model, torch.device(offload_device.value), offloaded_states)
 
         # Reload states
         model.reload_states()
@@ -88,7 +91,7 @@ def run_model(model, param_groups, config_dict, hidden_dim, dtype, include, pin_
         for adam_exp_avg_sq_expected, adam_exp_avg_sq_restored in zip(adam_exp_avg_sq, adam_exp_avg_sq_restored):
             assert torch.equal(adam_exp_avg_sq_expected, adam_exp_avg_sq_restored)
 
-        validate_device(model, torch.device(get_accelerator().current_device_name()), include)
+        validate_device(model, torch.device(get_accelerator().current_device_name()), offloaded_states)
 
     # Needed in ZeRO 3. Not doing so can give memory leak
     model.destroy()
@@ -131,5 +134,6 @@ class TestOffloadStates(DistributedTest):
             "params": [p for n, p in model.named_parameters() if 'bias' in n],
             "weight_decay": 0.0
         }]
-        include = None if included_state is None else [included_state]
-        run_model(model, param_groups, config_dict, hidden_dim, torch.bfloat16, include, pin_memory, non_blocking)
+        offloaded_states = None if included_state is None else [included_state]
+        run_model(model, param_groups, config_dict, hidden_dim, torch.bfloat16, offloaded_states, pin_memory,
+                  non_blocking)

--- a/tests/unit/runtime/zero/test_zero_tensor_fragment.py
+++ b/tests/unit/runtime/zero/test_zero_tensor_fragment.py
@@ -6,8 +6,9 @@
 import pytest
 import deepspeed.comm as dist
 import torch
+import math
 
-from unit.common import DistributedTest, preferred_dtype
+from unit.common import DistributedTest
 from unit.simple_model import random_dataloader, SimpleModel
 from unit.util import bf16_required_version_check
 
@@ -16,9 +17,11 @@ from deepspeed.utils import safe_get_full_fp32_param, safe_get_full_grad, safe_g
 from deepspeed.utils import safe_set_full_fp32_param, safe_set_full_grad, safe_set_full_optimizer_state
 from deepspeed.utils import safe_get_local_fp32_param, safe_get_local_grad, safe_get_local_optimizer_state
 from deepspeed.utils import safe_set_local_fp32_param, safe_set_local_grad, safe_set_local_optimizer_state
+from deepspeed.utils import safe_update_full_grad_vectorized
 from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum
 from deepspeed.ops.aio import AsyncIOBuilder
 from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.swap_tensor import MIN_SWAPPABLE_BYTES
 
 WEIGHT_KEY = 'weight'
 FIRST_ORDER_KEY = 'exp_avg'
@@ -92,10 +95,14 @@ class TestTensorFragmentGet(DistributedTest):
     world_size = 2
     reuse_dist_env = True
 
+    @pytest.mark.parametrize('dtype', [torch.bfloat16, torch.float16, torch.float32])
     @pytest.mark.parametrize('api_type', ['local', 'full'])
     @pytest.mark.parametrize('zero_stage', [1, 2, 3])
     @pytest.mark.parametrize('offload_device', [OffloadDeviceEnum.none, OffloadDeviceEnum.cpu, OffloadDeviceEnum.nvme])
-    def test_zero_fragments(self, tmpdir, api_type, zero_stage, offload_device, frozen_weights):
+    def test_zero_fragments(self, tmpdir, dtype, api_type, zero_stage, offload_device, frozen_weights):
+        if not dtype in get_accelerator().supported_dtypes():
+            pytest.skip(f"{get_accelerator()._name} does not support {dtype} data type")
+
         if offload_device == OffloadDeviceEnum.nvme:
             if zero_stage != 3:
                 pytest.skip(f"Nvme offload not supported for zero stage {zero_stage}")
@@ -118,9 +125,10 @@ class TestTensorFragmentGet(DistributedTest):
                 "stage": zero_stage,
             }
         }
-        if get_accelerator().is_fp16_supported():
+
+        if dtype == torch.half:
             config_dict["fp16"] = {"enabled": True, "initial_scale_power": 2}
-        elif get_accelerator().is_bf16_supported():
+        elif dtype == torch.bfloat16:
             config_dict["bf16"] = {"enabled": True}
 
         if offload_device == OffloadDeviceEnum.cpu:
@@ -131,7 +139,7 @@ class TestTensorFragmentGet(DistributedTest):
                 "nvme_path": str(tmpdir)
             }
 
-        hidden_dim = 128
+        hidden_dim = MIN_SWAPPABLE_BYTES
         if zero_stage == 3:
             with deepspeed.zero.Init(config_dict_or_path=config_dict):
                 model = MyModel(hidden_dim, frozen_weights)
@@ -141,10 +149,9 @@ class TestTensorFragmentGet(DistributedTest):
         validate_after_bwd = lambda model: validate_tensor(model, api_type, opt_states=False)
         validate_after_step = lambda model: validate_tensor(model, api_type, opt_states=True)
 
-        run_fragmented_model(model, config_dict, hidden_dim, preferred_dtype(), validate_after_bwd,
-                             validate_after_step)
+        run_fragmented_model(model, config_dict, hidden_dim, dtype, validate_after_bwd, validate_after_step)
 
-    def test_bf16_fragments(self, frozen_weights):
+    def test_bf16_optimizer_fragments(self, frozen_weights):
         if get_accelerator().device_name() == "cpu":
             pytest.skip("CPU accelerator does not support this test yet.")
         if frozen_weights:
@@ -181,7 +188,7 @@ class TestTensorFragmentGet(DistributedTest):
         run_fragmented_model(model, config_dict, hidden_dim, torch.bfloat16, validate_after_bwd, validate_after_step)
 
 
-def create_random_values(model, key_list, group, grad_dtype, use_cuda=True):
+def create_random_values(model, key_list, group, grad_dtype):
     param_values = {}
     for n, lp in model.named_parameters():
         param_shape = lp.ds_shape if hasattr(lp, 'ds_id') else lp.shape
@@ -205,6 +212,25 @@ def set_param_values_with_dict(model, value_dict):
                 safe_set_full_optimizer_state(lp, value_tensor, key)
 
 
+def update_param_values_with_dict(model, value_dict):
+    new_grad_values = {}
+    for n, lp in model.named_parameters():
+        if GRADIENT_KEY in value_dict[n]:
+            new_grad_values[id(lp)] = value_dict[n][GRADIENT_KEY]
+
+    def update_gradient_callback(old_value, param):
+        return new_grad_values[id(param)]
+
+    update_param_list = []
+    for n, lp in model.named_parameters():
+        for key, value_tensor in value_dict[n].items():
+            if key == GRADIENT_KEY:
+                update_param_list.append(lp)
+
+    if len(update_param_list) > 0:
+        safe_update_full_grad_vectorized(update_param_list, update_gradient_callback)
+
+
 def validate_param_values_with_dict(model, value_dict):
     for n, lp in model.named_parameters():
         for key, expected_tensor in value_dict[n].items():
@@ -218,16 +244,14 @@ def validate_param_values_with_dict(model, value_dict):
             assert torch.equal(expected_tensor, actual_tensor)
 
 
-def create_random_values_for_local(model, key_list, group, grad_dtype, use_cuda=True):
+def create_random_values_for_local(model, key_list, group, grad_dtype):
     param_values = {}
     for n, lp in model.named_parameters():
         param_shape = lp.ds_tensor.shape
         param_values[n] = {}
         for key in key_list:
-            device = model.device if use_cuda else "cpu"
             dtype = grad_dtype if key == GRADIENT_KEY else torch.float32
-            rand_value = torch.rand(param_shape, dtype=dtype, device=device)
-            # dist.broadcast(rand_value, src=0, group=group)
+            rand_value = torch.rand(param_shape, dtype=dtype, device=model.device)
             param_values[n][key] = rand_value
     return param_values
 
@@ -261,7 +285,8 @@ helper_funcs_mapping = {
     "full": {
         "create_random_values": create_random_values,
         "set_param_values_with_dict": set_param_values_with_dict,
-        "validate_param_values_with_dict": validate_param_values_with_dict
+        "update_param_values_with_dict": update_param_values_with_dict,
+        "validate_param_values_with_dict": validate_param_values_with_dict,
     },
     "local": {
         "create_random_values": create_random_values_for_local,
@@ -272,7 +297,7 @@ helper_funcs_mapping = {
 
 
 @pytest.mark.parametrize('dtype', [torch.bfloat16, torch.float16, torch.float32])
-class TestTensorFragmentUpdate(DistributedTest):
+class TestTensorFragmentSet(DistributedTest):
     # Need multiple gpus to test possible hanging
     world_size = 2
     reuse_dist_env = True
@@ -281,6 +306,8 @@ class TestTensorFragmentUpdate(DistributedTest):
     @pytest.mark.parametrize('zero_stage', [1, 2, 3])
     @pytest.mark.parametrize('offload_device', [OffloadDeviceEnum.none, OffloadDeviceEnum.cpu, OffloadDeviceEnum.nvme])
     def test_zero_fragments(self, tmpdir, api_type, zero_stage, offload_device, dtype):
+        if not dtype in get_accelerator().supported_dtypes():
+            pytest.skip(f"{get_accelerator()._name} does not support {dtype} data type")
 
         if dtype == torch.bfloat16 and not bf16_required_version_check(accelerator_check=False):
             pytest.skip(
@@ -319,13 +346,11 @@ class TestTensorFragmentUpdate(DistributedTest):
             }
 
         if dtype == torch.float16:
-            if not get_accelerator().is_fp16_supported():
-                pytest.skip("fp16 is not supported")
             config_dict["fp16"] = {"enabled": True, "initial_scale_power": 8}
         elif dtype == torch.bfloat16:
             config_dict["bf16"] = {"enabled": True}
 
-        hidden_dim = 128
+        hidden_dim = int(math.sqrt(MIN_SWAPPABLE_BYTES))
         if zero_stage == 3:
             config_dict["zero_optimization"]["param_persistence_threshold"] = hidden_dim
             with deepspeed.zero.Init(config_dict_or_path=config_dict):
@@ -341,17 +366,90 @@ class TestTensorFragmentUpdate(DistributedTest):
         def after_bwd_validate_func(model):
             state_keys = [WEIGHT_KEY, GRADIENT_KEY]
             helper_funcs = helper_funcs_mapping[api_type]
-            optim_state_values = helper_funcs["create_random_values"](
-                model, state_keys, group, grad_dtype=dtype, use_cuda=offload_device == OffloadDeviceEnum.none)
+            optim_state_values = helper_funcs["create_random_values"](model, state_keys, group, grad_dtype=dtype)
             helper_funcs["set_param_values_with_dict"](model, optim_state_values)
             helper_funcs["validate_param_values_with_dict"](model, optim_state_values)
 
         def after_step_validate_func(model):
             state_keys = [WEIGHT_KEY, FIRST_ORDER_KEY, SECOND_ORDER_KEY]
             helper_funcs = helper_funcs_mapping[api_type]
-            optim_state_values = helper_funcs["create_random_values"](
-                model, state_keys, group, grad_dtype=dtype, use_cuda=offload_device == OffloadDeviceEnum.none)
+            optim_state_values = helper_funcs["create_random_values"](model, state_keys, group, grad_dtype=dtype)
             helper_funcs["set_param_values_with_dict"](model, optim_state_values)
             helper_funcs["validate_param_values_with_dict"](model, optim_state_values)
+
+        run_fragmented_model(model, config_dict, hidden_dim, dtype, after_bwd_validate_func, after_step_validate_func)
+
+
+@pytest.mark.parametrize('dtype', [torch.bfloat16, torch.float16, torch.float32])
+class TestTensorFragmentUpdate(DistributedTest):
+    # Need multiple gpus to test possible hanging
+    world_size = 2
+    reuse_dist_env = True
+
+    @pytest.mark.parametrize('torch_adam', [False, True])
+    @pytest.mark.parametrize('zero_stage', [1, 2, 3])
+    @pytest.mark.parametrize('offload_device', [OffloadDeviceEnum.none, OffloadDeviceEnum.cpu, OffloadDeviceEnum.nvme])
+    def test_zero_fragments(self, tmpdir, torch_adam, zero_stage, offload_device, dtype):
+        if not dtype in get_accelerator().supported_dtypes():
+            pytest.skip(f"{get_accelerator()._name} does not support {dtype} data type")
+
+        if offload_device == OffloadDeviceEnum.nvme:
+            if zero_stage != 3:
+                pytest.skip(f"Nvme offload not supported for zero stage {zero_stage}")
+            if not deepspeed.ops.__compatible_ops__[AsyncIOBuilder.NAME]:
+                pytest.skip('Skip tests since async-io is not compatible')
+
+        config_dict = {
+            "train_micro_batch_size_per_gpu": 1,
+            "steps_per_print": 1,
+            "optimizer": {
+                "type": "Adam",
+                "params": {
+                    "lr": 1e-6,
+                    "torch_adam": torch_adam
+                }
+            },
+            "zero_optimization": {
+                "stage": zero_stage,
+            }
+        }
+
+        if offload_device == OffloadDeviceEnum.cpu:
+            config_dict["zero_optimization"]["offload_optimizer"] = {"device": offload_device}
+        elif offload_device == OffloadDeviceEnum.nvme:
+            config_dict["zero_optimization"]["offload_optimizer"] = {
+                "device": offload_device,
+                "nvme_path": str(tmpdir)
+            }
+
+        if dtype == torch.float16:
+            config_dict["fp16"] = {"enabled": True, "initial_scale_power": 8}
+        elif dtype == torch.bfloat16:
+            config_dict["bf16"] = {"enabled": True}
+
+        hidden_dim = int(math.sqrt(MIN_SWAPPABLE_BYTES))
+        if zero_stage == 3:
+            config_dict["zero_optimization"]["param_persistence_threshold"] = hidden_dim
+            with deepspeed.zero.Init(config_dict_or_path=config_dict):
+                model = SimpleModel(hidden_dim)
+        else:
+            model = SimpleModel(hidden_dim)
+
+        world = dist.get_world_size()
+        group = dist.new_group(ranks=list(range(world)))
+
+        dist.barrier()
+
+        api_type = "full"
+
+        def after_bwd_validate_func(model):
+            state_keys = [GRADIENT_KEY]
+            helper_funcs = helper_funcs_mapping[api_type]
+            optim_state_values = helper_funcs["create_random_values"](model, state_keys, group, grad_dtype=dtype)
+            helper_funcs["update_param_values_with_dict"](model, optim_state_values)
+            helper_funcs["validate_param_values_with_dict"](model, optim_state_values)
+
+        def after_step_validate_func(model):
+            pass
 
         run_fragmented_model(model, config_dict, hidden_dim, dtype, after_bwd_validate_func, after_step_validate_func)


### PR DESCRIPTION
Recreated from original PR: https://github.com/deepspeedai/DeepSpeed/pull/7046

- Extend APIs for [debugging](https://deepspeed.readthedocs.io/en/latest/zero3.html#debugging) and [modifying](https://deepspeed.readthedocs.io/en/latest/zero3.html#modifying-partitioned-states) ZeRO partitioned states to NVMe offload. 
- Add vectorized update API. This is performance-critical for NVMe offloading scenarios. 